### PR TITLE
Backend: fixed bad Javascript deep clone

### DIFF
--- a/BackEnd/lib/upload_functions.js
+++ b/BackEnd/lib/upload_functions.js
@@ -56,11 +56,11 @@ async function loadIndexJson(dirPath) {
  * a group has a structure like { title: "g1", exercises: ["ex1", "ex2", ...] }
  */
 async function saveIndexJson(dirPath, groups) {
-    const indexObject = Object.assign({}, defaultIndexObj);
+    const indexObject = JSON.parse(JSON.stringify(defaultIndexObj));
     const filePath = path.join(dirPath, defaultIndexJsonFilename);
 
     for (let i = 0; i < groups.length; i++) {
-        indexObject.groups[groupPrefix + i] = groups[i];
+        indexObject.groups[`${groupPrefix}${i}`] = groups[i];
     }
     return Promise.resolve(JSON.stringify(indexObject, null, 2))
         .then(buffer => fsPromises.writeFile(filePath, buffer));


### PR DESCRIPTION
This PR fix the issue when user get the last created `index.json`, this is due to a bad Javascript cloning object.